### PR TITLE
Migrate existing adapter scripts to this repo as GitHub actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
 # Chartboost Mediation iOS Actions
 Repository of GitHub Actions for the Chartboost Mediation iOS Adapter ecosystem.
+
+## adapter-smoke-test
+
+Validates changes to an adapter.
+
+### Use example
+
+Add to your GitHub workflow:
+
+```
+jobs:
+  validate-podspec:
+    runs-on: macos-latest
+    steps:
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+```
+
+## create-adapter-release-branch
+
+This action creates a new adapter release branch, validates inputs, applies boilerplate changes, and opens a PR.
+
+### Requirements
+
+- A `GITHUB_TOKEN` environment variable with a GitHub token that has permission to push and create PRs in the adapter repository.
+
+### Use example
+
+Add to your GitHub workflow:
+
+```
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUBSERVICETOKEN }}
+
+jobs:
+  create-release-branch:
+    steps:
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+        with:
+          adapter-version: "4.5.3.0.0"
+          partner-version: "~> 5.3.0"
+``` 
+
+## release-adapter
+
+This action releases a new adapter version.
+
+### Requirements
+
+- A `GITHUB_TOKEN` environment variable with a GitHub token that has permission to push tags and create GitHub releases in the adapter repository.
+- A `COCOAPODS_TRUNK_TOKEN` environment variable with a CocoaPods token that has permission to push new adapter pod versions to trunk.
+
+### Use example
+
+Add to your GitHub workflow:
+
+```
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUBSERVICETOKEN }}
+  COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+
+jobs:
+  release-adapter:
+    steps:
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+``` 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Validates changes to an adapter.
 
 | name | type | required | default | discussion |
 | ---- | ---- | ---- | ---- | ---- |
-| allow-warnings | boolean | no | false | Indicates if warnings should be allowed when linting the podspec | 
+| `allow-warnings` | boolean | no | false | Indicates if warnings should be allowed when linting the podspec | 
 
 ### Use example
 
@@ -63,7 +63,7 @@ This action releases a new adapter version.
 
 | name | type | required | default | discussion |
 | ---- | ---- | ---- | ---- | ---- |
-| allow-warnings | boolean | no | false | Indicates if warnings should be allowed when linting the podspec |
+| `allow-warnings` | boolean | no | false | Indicates if warnings should be allowed when linting the podspec |
 
 ### Use example
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Repository of GitHub Actions for the Chartboost Mediation iOS Adapter ecosystem.
 
 Validates changes to an adapter.
 
+### Inputs
+
+| name | type | required | default | discussion |
+| ---- | ---- | ---- | ---- | ---- |
+| allow-warnings | boolean | no | false | Indicates if warnings should be allowed when linting the podspec | 
+
 ### Use example
 
 Add to your GitHub workflow:
@@ -15,6 +21,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+        with:
+          allow-warnings: true
 ```
 
 ## create-adapter-release-branch
@@ -50,6 +58,12 @@ This action releases a new adapter version.
 
 - A `GITHUB_TOKEN` environment variable with a GitHub token that has permission to push tags and create GitHub releases in the adapter repository.
 - A `COCOAPODS_TRUNK_TOKEN` environment variable with a CocoaPods token that has permission to push new adapter pod versions to trunk.
+
+### Inputs
+
+| name | type | required | default | discussion |
+| ---- | ---- | ---- | ---- | ---- |
+| allow-warnings | boolean | no | false | Indicates if warnings should be allowed when linting the podspec |
 
 ### Use example
 

--- a/adapter-smoke-test/action.yml
+++ b/adapter-smoke-test/action.yml
@@ -1,0 +1,20 @@
+name: 'Adapter Smoke Tests'
+
+description: 'Validates changes to an adapter.'
+
+runs:
+  using: 'composite'
+  steps:
+
+      # Check out the repo.
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    # Check that the adapter version in the podpsec and in the PartnerAdapter Swift implementation are the same.
+    - name: Validate Adapter and Podspec Version Match
+      run: ruby ./Scripts/validate-adapter-version.rb
+      shell: bash
+
+    # Validate the podspec.
+    - name: Validate Podspec
+      run: pod lib lint --verbose

--- a/adapter-smoke-test/action.yml
+++ b/adapter-smoke-test/action.yml
@@ -12,7 +12,7 @@ runs:
 
     # Check that the adapter version in the podpsec and in the PartnerAdapter Swift implementation are the same.
     - name: Validate Adapter and Podspec Version Match
-      run: ruby ./Scripts/validate-adapter-version.rb
+      run: ruby ./scripts/validate-adapter-version.rb
       shell: bash
 
     # Validate the podspec.

--- a/adapter-smoke-test/action.yml
+++ b/adapter-smoke-test/action.yml
@@ -12,7 +12,7 @@ runs:
 
     # Check that the adapter version in the podpsec and in the PartnerAdapter Swift implementation are the same.
     - name: Validate Adapter and Podspec Version Match
-      run: ruby ./scripts/validate-adapter-version.rb
+      run: ruby "${{ github.action_path }}/../scripts/validate-adapter-version.rb"
       shell: bash
 
     # Validate the podspec.

--- a/adapter-smoke-test/action.yml
+++ b/adapter-smoke-test/action.yml
@@ -2,6 +2,13 @@ name: 'Adapter Smoke Tests'
 
 description: 'Validates changes to an adapter.'
 
+inputs:
+  allow-warnings:
+    type: boolean
+    description: 'Indicates if warnings should be allowed when linting the podspec'
+    required: false
+    default: false
+
 runs:
   using: 'composite'
   steps:
@@ -17,5 +24,5 @@ runs:
 
     # Validate the podspec.
     - name: Validate Podspec
-      run: pod lib lint --verbose
+      run: pod lib lint --verbose ${{ inputs.allow-warnings && '--allow-warnings' || '' }}
       shell: bash

--- a/adapter-smoke-test/action.yml
+++ b/adapter-smoke-test/action.yml
@@ -18,3 +18,4 @@ runs:
     # Validate the podspec.
     - name: Validate Podspec
       run: pod lib lint --verbose
+      shell: bash

--- a/create-adapter-release-branch/action.yml
+++ b/create-adapter-release-branch/action.yml
@@ -1,4 +1,4 @@
-name: 'Create Release Branch'
+name: 'Create Adapter Release Branch'
 
 description: 'Creates a new adapter release branch, validates inputs, applies boilerplate changes, and opens a PR.'
 

--- a/create-adapter-release-branch/action.yml
+++ b/create-adapter-release-branch/action.yml
@@ -22,17 +22,17 @@ runs:
 
     # Validate adapter and partner versions are compatible.
     - name: Validate Adapter and Partner Version Match
-      run: ruby ./scripts/validate-adapter-and-partner-versions.rb "${{ inputs.adapter-version }}" "${{ inputs.partner-version }}"
+      run: ruby "${{ github.action_path }}/../scripts/validate-adapter-and-partner-versions.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }}"
       shell: bash
 
     # Validate adapter version is well-formed and not already released.
     - name: Validate Adapter Version
-      run: ruby ./scripts/validate-new-release-version.rb "${{ inputs.adapter-version }}"
+      run: ruby "${{ github.action_path }}/../scripts/validate-new-release-version.rb ${{ inputs.adapter-version }}"
       shell: bash
 
     # Validate partner version is well-formed.
     - name: Validate Partner Version
-      run: ruby ./scripts/validate-partner-version.rb "${{ inputs.partner-version }}"
+      run: ruby "${{ github.action_path }}/../scripts/validate-partner-version.rb ${{ inputs.partner-version }}"
       shell: bash
 
     # Create and checkout branch
@@ -42,17 +42,17 @@ runs:
 
     # Update version strings in podspec.
     - name: Update Version Strings in Podspec
-      run: ruby ./scripts/update-podspec-versions.rb "${{ inputs.adapter-version }}" "${{ inputs.partner-version }}"
+      run: ruby "${{ github.action_path }}/../scripts/update-podspec-versions.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }}"
       shell: bash
 
     # Update version string in main adapter class.
     - name: Update Version String in Partner Adapter Class
-      run: ruby ./scripts/update-adapter-class-version.rb "${{ inputs.adapter-version }}"
+      run: ruby "${{ github.action_path }}/../scripts/update-adapter-class-version.rb ${{ inputs.adapter-version }}"
       shell: bash
 
     # Add new changelog entry for the current adapter version.
     - name: Add Changelog Entry
-      run: ruby ./scripts/add-changelog-entry.rb "${{ inputs.adapter-version }}" "${{ inputs.partner-version }}"
+      run: ruby "${{ github.action_path }}/../scripts/add-changelog-entry.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }}"
       shell: bash
 
     # Commit and push changes.

--- a/create-adapter-release-branch/action.yml
+++ b/create-adapter-release-branch/action.yml
@@ -63,4 +63,4 @@ runs:
     # Open a pull request from the new branch to main.
     - name: Open Pull Request
       run: gh pr create --base "main" --reviewer "@ChartBoost/helium-ios" --title "Update Version to ${{ inputs.adapter-version }}" --body "Adapter version '${{ inputs.adapter-version }}', partner version '${{ inputs.partner-version }}'" --label "do not merge"
-
+      shell: bash

--- a/create-adapter-release-branch/action.yml
+++ b/create-adapter-release-branch/action.yml
@@ -22,17 +22,17 @@ runs:
 
     # Validate adapter and partner versions are compatible.
     - name: Validate Adapter and Partner Version Match
-      run: ruby "${{ github.action_path }}/../scripts/validate-adapter-and-partner-versions.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }}"
+      run: ruby "${{ github.action_path }}/../scripts/validate-adapter-and-partner-versions.rb" "${{ inputs.adapter-version }}" "${{ inputs.partner-version }}"
       shell: bash
 
     # Validate adapter version is well-formed and not already released.
     - name: Validate Adapter Version
-      run: ruby "${{ github.action_path }}/../scripts/validate-new-release-version.rb ${{ inputs.adapter-version }}"
+      run: ruby "${{ github.action_path }}/../scripts/validate-new-release-version.rb" "${{ inputs.adapter-version }}"
       shell: bash
 
     # Validate partner version is well-formed.
     - name: Validate Partner Version
-      run: ruby "${{ github.action_path }}/../scripts/validate-partner-version.rb ${{ inputs.partner-version }}"
+      run: ruby "${{ github.action_path }}/../scripts/validate-partner-version.rb" "${{ inputs.partner-version }}"
       shell: bash
 
     # Create and checkout branch
@@ -42,17 +42,17 @@ runs:
 
     # Update version strings in podspec.
     - name: Update Version Strings in Podspec
-      run: ruby "${{ github.action_path }}/../scripts/update-podspec-versions.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }}"
+      run: ruby "${{ github.action_path }}/../scripts/update-podspec-versions.rb" "${{ inputs.adapter-version }}" "${{ inputs.partner-version }}"
       shell: bash
 
     # Update version string in main adapter class.
     - name: Update Version String in Partner Adapter Class
-      run: ruby "${{ github.action_path }}/../scripts/update-adapter-class-version.rb ${{ inputs.adapter-version }}"
+      run: ruby "${{ github.action_path }}/../scripts/update-adapter-class-version.rb" "${{ inputs.adapter-version }}"
       shell: bash
 
     # Add new changelog entry for the current adapter version.
     - name: Add Changelog Entry
-      run: ruby "${{ github.action_path }}/../scripts/add-changelog-entry.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }}"
+      run: ruby "${{ github.action_path }}/../scripts/add-changelog-entry.rb" "${{ inputs.adapter-version }}" "${{ inputs.partner-version }}"
       shell: bash
 
     # Commit and push changes.

--- a/create-release-branch/action.yml
+++ b/create-release-branch/action.yml
@@ -22,17 +22,17 @@ runs:
 
     # Validate adapter and partner versions are compatible.
     - name: Validate Adapter and Partner Version Match
-      run: ruby "${{ github.action_path }}/../scripts/validate-adapter-and-partner-versions.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }}"
+      run: ruby ./scripts/validate-adapter-and-partner-versions.rb "${{ inputs.adapter-version }}" "${{ inputs.partner-version }}"
       shell: bash
 
     # Validate adapter version is well-formed and not already released.
     - name: Validate Adapter Version
-      run: ruby "${{ github.action_path }}/../scripts/validate-new-release-version.rb ${{ inputs.adapter-version }}"
+      run: ruby ./scripts/validate-new-release-version.rb "${{ inputs.adapter-version }}"
       shell: bash
 
     # Validate partner version is well-formed.
     - name: Validate Partner Version
-      run: ruby "${{ github.action_path }}/../scripts/validate-partner-version.rb ${{ inputs.partner-version }}"
+      run: ruby ./scripts/validate-partner-version.rb "${{ inputs.partner-version }}"
       shell: bash
 
     # Create and checkout branch
@@ -42,17 +42,17 @@ runs:
 
     # Update version strings in podspec.
     - name: Update Version Strings in Podspec
-      run: ruby "${{ github.action_path }}/../scripts/update-podspec-versions.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }}"
+      run: ruby ./scripts/update-podspec-versions.rb "${{ inputs.adapter-version }}" "${{ inputs.partner-version }}"
       shell: bash
 
     # Update version string in main adapter class.
     - name: Update Version String in Partner Adapter Class
-      run: ruby "${{ github.action_path }}/../scripts/update-adapter-class-version.rb ${{ inputs.adapter-version }}"
+      run: ruby ./scripts/update-adapter-class-version.rb "${{ inputs.adapter-version }}"
       shell: bash
 
     # Add new changelog entry for the current adapter version.
     - name: Add Changelog Entry
-      run: ruby "${{ github.action_path }}/../scripts/add-changelog-entry.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }}"
+      run: ruby ./scripts/add-changelog-entry.rb "${{ inputs.adapter-version }}" "${{ inputs.partner-version }}"
       shell: bash
 
     # Commit and push changes.

--- a/create-release-branch/action.yml
+++ b/create-release-branch/action.yml
@@ -1,6 +1,6 @@
 name: 'Create Release Branch'
 
-description: 'Creates a new adapter release branch making boilerplate changes and opening a PR for it.'
+description: 'Creates a new adapter release branch, validates inputs, applies boilerplate changes, and opens a PR.'
 
 inputs:
   adapter-version:

--- a/create-release-branch/action.yml
+++ b/create-release-branch/action.yml
@@ -1,0 +1,66 @@
+name: 'Create Release Branch'
+
+description: 'Creates a new adapter release branch making boilerplate changes and opening a PR for it.'
+
+inputs:
+  adapter-version:
+    type: string
+    description: 'Adapter version (e.g. ''4.9.2.0.0'')'
+    required: true
+  partner-version:
+    type: string
+    description: 'Partner version (e.g. ''~> 9.2.0'')'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+  
+    # Check out the repo at the specified branch or tag.
+    - name: Checkout Branch
+      uses: actions/checkout@v3
+
+    # Validate adapter and partner versions are compatible.
+    - name: Validate Adapter and Partner Version Match
+      run: ruby "${{ github.action_path }}/../scripts/validate-adapter-and-partner-versions.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }}"
+      shell: bash
+
+    # Validate adapter version is well-formed and not already released.
+    - name: Validate Adapter Version
+      run: ruby "${{ github.action_path }}/../scripts/validate-new-release-version.rb ${{ inputs.adapter-version }}"
+      shell: bash
+
+    # Validate partner version is well-formed.
+    - name: Validate Partner Version
+      run: ruby "${{ github.action_path }}/../scripts/validate-partner-version.rb ${{ inputs.partner-version }}"
+      shell: bash
+
+    # Create and checkout branch
+    - name: Create Branch
+      run: git checkout -b "release/${{ inputs.adapter-version }}"
+      shell: bash
+
+    # Update version strings in podspec.
+    - name: Update Version Strings in Podspec
+      run: ruby "${{ github.action_path }}/../scripts/update-podspec-versions.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }}"
+      shell: bash
+
+    # Update version string in main adapter class.
+    - name: Update Version String in Partner Adapter Class
+      run: ruby "${{ github.action_path }}/../scripts/update-adapter-class-version.rb ${{ inputs.adapter-version }}"
+      shell: bash
+
+    # Add new changelog entry for the current adapter version.
+    - name: Add Changelog Entry
+      run: ruby "${{ github.action_path }}/../scripts/add-changelog-entry.rb ${{ inputs.adapter-version }} ${{ inputs.partner-version }}"
+      shell: bash
+
+    # Commit and push changes.
+    - name: Push Changes
+      run: git add *.podspec CHANGELOG.md Source/*Adapter.swift && git commit -m "[AUTO-GENERATED] Update version to ${{ inputs.adapter-version }}" && git push -u origin "release/${{ inputs.adapter-version }}"
+      shell: bash
+
+    # Open a pull request from the new branch to main.
+    - name: Open Pull Request
+      run: gh pr create --base "main" --reviewer "@ChartBoost/helium-ios" --title "Update Version to ${{ inputs.adapter-version }}" --body "Adapter version '${{ inputs.adapter-version }}', partner version '${{ inputs.partner-version }}'" --label "do not merge"
+

--- a/release-adapter/action.yml
+++ b/release-adapter/action.yml
@@ -9,6 +9,8 @@ runs:
     # Check out the repo.
     - name: Checkout Branch
       uses: actions/checkout@v3
+      with:
+        token: ${{ env.GITHUB_TOKEN }}
 
     # Obtain the new adapter version.
     - name: Obtain Adapter Version

--- a/release-adapter/action.yml
+++ b/release-adapter/action.yml
@@ -24,6 +24,7 @@ runs:
     # Push the podspec.
     - name: Push Podspec
       run: pod trunk push --verbose
+      shell: bash
 
     # Create GitHub release.
     - name: Create Release

--- a/release-adapter/action.yml
+++ b/release-adapter/action.yml
@@ -13,7 +13,7 @@ runs:
     # Obtain the new adapter version.
     - name: Obtain Adapter Version
       id: release_version
-      run: echo "version=$(ruby ./scripts/adapter-version.rb)" >> $GITHUB_OUTPUT
+      run: echo "version=$(ruby ${{ github.action_path }}/../scripts/adapter-version.rb)" >> $GITHUB_OUTPUT
       shell: bash
 
     # Push the release tag.

--- a/release-adapter/action.yml
+++ b/release-adapter/action.yml
@@ -1,0 +1,36 @@
+name: 'Release Adapter'
+
+description: 'Releases a new adapter version.'
+
+runs:
+  using: 'composite'
+  steps:
+  
+    # Check out the repo..
+    - name: Checkout Branch
+      uses: actions/checkout@v3
+
+    # Obtain the new adapter version.
+    - name: Obtain Adapter Version
+      id: release_version
+      run: echo "version=$(ruby ./Scripts/adapter-version.rb)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    # Push the release tag.
+    - name: Tag
+      run: git tag ${{ steps.release_version.outputs.version }} && git push origin ${{ steps.release_version.outputs.version }}
+      shell: bash
+
+    # Push the podspec.
+    - name: Push Podspec
+      run: pod trunk push --verbose
+
+    # Create GitHub release.
+    - name: Create Release
+      uses: actions/create-release@v1
+      with:
+        tag_name: ${{ steps.release_version.outputs.version }}
+        release_name: ${{ steps.release_version.outputs.version }}
+        body: ''
+        draft: false
+        prerelease: false

--- a/release-adapter/action.yml
+++ b/release-adapter/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
   
-    # Check out the repo..
+    # Check out the repo.
     - name: Checkout Branch
       uses: actions/checkout@v3
 

--- a/release-adapter/action.yml
+++ b/release-adapter/action.yml
@@ -2,6 +2,13 @@ name: 'Release Adapter'
 
 description: 'Releases a new adapter version.'
 
+inputs:
+  allow-warnings:
+    type: boolean
+    description: 'Indicates if warnings should be allowed when linting the podspec'
+    required: false
+    default: false
+
 runs:
   using: 'composite'
   steps:
@@ -25,7 +32,7 @@ runs:
 
     # Push the podspec.
     - name: Push Podspec
-      run: pod trunk push --verbose
+      run: pod trunk push --verbose ${{ inputs.allow-warnings && '--allow-warnings' || '' }}
       shell: bash
 
     # Create GitHub release.

--- a/release-adapter/action.yml
+++ b/release-adapter/action.yml
@@ -13,7 +13,7 @@ runs:
     # Obtain the new adapter version.
     - name: Obtain Adapter Version
       id: release_version
-      run: echo "version=$(ruby ./Scripts/adapter-version.rb)" >> $GITHUB_OUTPUT
+      run: echo "version=$(ruby ./scripts/adapter-version.rb)" >> $GITHUB_OUTPUT
       shell: bash
 
     # Push the release tag.

--- a/scripts/adapter-version.rb
+++ b/scripts/adapter-version.rb
@@ -1,0 +1,4 @@
+require_relative 'common'
+
+# Take podspec version as the adapter version and output to console
+puts podspec_version

--- a/scripts/add-changelog-entry.rb
+++ b/scripts/add-changelog-entry.rb
@@ -1,0 +1,24 @@
+# Adds a new changelog entry using its current podspec version.
+# Assumes that the partner SDK is the last dependency in the podspec file.
+
+require_relative 'common'
+
+# Parse the version strings from the arguments
+abort "Missing argument. Requires: adapter version string, partner version string." unless ARGV.count == 2
+adapter_version = ARGV[0]
+partner_version = ARGV[1]
+
+# Strip the cocoapods optimistic operation from the partner version if it exists
+partner_version = partner_version.delete_prefix('~> ')
+
+# Obtain the partner SDK name from the podspec
+partner_sdk_name = podspec_partner_sdk_name()
+
+# Read the changelog file
+changelog = read_changelog()
+
+# Add the new entry right before the last one, if the entry does not already exist for this version
+if !changelog.include? "### #{adapter_version}"
+  changelog = changelog.sub("###", "### #{adapter_version}\n- This version of the adapters has been certified with #{partner_sdk_name} #{partner_version}.\n\n###")
+  write_changelog(changelog)
+end

--- a/scripts/common.rb
+++ b/scripts/common.rb
@@ -1,0 +1,138 @@
+# Common definitions used by other scripts.
+
+PODSPEC_PATH_PATTERN = "*.podspec"
+PODSPEC_VERSION_REGEX = /^(\s*spec\.version\s*=\s*')([0-9]+(?>\.[0-9]+){4,5})('\s*)$/
+PODSPEC_NAME_REGEX = /^\s*spec\.name\s*=\s*'([^']+)'\s*$/
+PODSPEC_PARTNER_REGEX = /spec\.dependency\s*'([^']+)'/
+CHANGELOG_PATH = "CHANGELOG.md"
+ADAPTER_CLASS_PREFIX = "ChartboostMediationAdapter"
+ADAPTER_CLASS_VERSION_REGEX = /^(\s*let adapterVersion\s*=\s*")([^"]+)(".*)$/
+
+###########
+# PODSPEC #
+###########
+
+# Returns the podspec contents as a string.
+def read_podspec
+  # Read the podspec contents
+  text = File.read(podspec_file_path)
+  fail unless !text.nil?
+
+  # Return value
+  text
+end
+
+# Writes a string to the podspec file.
+def write_podspec(text)
+  File.open(podspec_file_path, "w") { |file| file.puts text }
+end
+
+# The path to the podspec file.
+def podspec_file_path
+  path = Dir.glob(PODSPEC_PATH_PATTERN).first
+  fail unless !path.nil?
+  path
+end
+
+# Returns the podspec version value.
+def podspec_version
+  # Obtain the podspec
+  text = read_podspec()
+
+  # Obtain the adapter version from the podspec
+  version = text.match(PODSPEC_VERSION_REGEX).captures[1]
+  fail unless !version.nil?
+
+  # Return value
+  version
+end
+
+# Returns the podspec version value.
+def podspec_name
+  # Obtain the podspec
+  text = read_podspec()
+
+  # Obtain the name from the podspec
+  name = text.match(PODSPEC_NAME_REGEX).captures.first
+  fail unless !name.nil?
+
+  # Return value
+  name
+end
+
+# Returns the podspec partner SDK dependency name.
+def podspec_partner_sdk_name
+  # Obtain the podspec
+  text = read_podspec()
+
+  # Obtain the partner SDK name from the podspec
+  partner_sdk = text.scan(PODSPEC_PARTNER_REGEX).last.first
+  fail unless !partner_sdk.nil?
+
+  # Return value
+  return partner_sdk
+end
+
+#############
+# CHANGELOG #
+#############
+
+# Returns the changelog contents as a string.
+def read_changelog
+  # Read the changelog contents
+  text = File.read(CHANGELOG_PATH)
+  fail unless !text.nil?
+
+  # Return value
+  text
+end
+
+# Writes a string to the changelog file.
+def write_changelog(text)
+  File.open(CHANGELOG_PATH, "w") { |file| file.puts text }
+end
+
+#################
+# ADAPTER CLASS #
+#################
+
+# Returns the main adapter class contents as a string.
+def read_adapter_class
+  # Read the contents
+  text = File.read(adapter_class_file_path)
+  fail unless !text.nil?
+
+  # Return value
+  text
+end
+
+# Writes a string to the main adapter class file.
+def write_adapter_class(text)
+  File.open(adapter_class_file_path, "w") { |file| file.puts text }
+end
+
+# The path to the main adapter class file.
+def adapter_class_file_path
+  # Obtain the partner name
+  partner_name = podspec_name.delete_prefix ADAPTER_CLASS_PREFIX
+
+  # Obtain the Adapter file path
+  path = Dir.glob("./Source/#{partner_name}Adapter.swift").first
+  fail unless !path.nil?
+
+  # Return value
+  path
+end
+
+# Returns the partner adapter version value in the main adapter class.
+def adapter_class_version
+  # Obtain the adapter class
+  text = read_adapter_class()
+
+  # Obtain the adapter version from the file
+  version = text.match(ADAPTER_CLASS_VERSION_REGEX).captures[1]
+  fail unless !version.nil?
+
+  # Return value
+  version
+end

--- a/scripts/update-adapter-class-version.rb
+++ b/scripts/update-adapter-class-version.rb
@@ -1,0 +1,16 @@
+# Updates the main PartnerAdapter class by replacing the adapter version string.
+
+require_relative 'common'
+
+# Parse the new version string from the arguments
+abort "Missing argument. Requires: version string." unless ARGV.count == 1
+new_version = ARGV[0]
+
+# Read the main adapter class file
+adapter_class = read_adapter_class()
+
+# Replace the partner adapter version string (capture group 2), keeping everything else the same (capture groups 1 and 3)
+adapter_class = adapter_class.sub(ADAPTER_CLASS_VERSION_REGEX, "\\1#{new_version}\\3")
+
+# Write the changes
+write_adapter_class(adapter_class)

--- a/scripts/update-podspec-versions.rb
+++ b/scripts/update-podspec-versions.rb
@@ -1,0 +1,24 @@
+# Updates the podspec by replacing the adapter and partner versions.
+
+require_relative 'common'
+
+# Parse the version strings from the arguments
+abort "Missing argument. Requires: adapter version string, partner version string." unless ARGV.count == 2
+adapter_version = ARGV[0]
+partner_version = ARGV[1]
+
+# Obtain the partner SDK name from the podspec
+partner_sdk_name = podspec_partner_sdk_name()
+
+# Read the podspec file
+podspec = read_podspec()
+
+# Replace the adapter version string in the podspec (capture group 2), keeping everything else the same (capture groups 1 and 3)
+podspec = podspec.sub(PODSPEC_VERSION_REGEX, "\\1#{adapter_version}\\3")
+
+# Replace the partner SDK version string in the podspec
+partner_sdk_version_regex = /(spec\.dependency\s*'#{partner_sdk_name}').*$/
+podspec = podspec.sub(partner_sdk_version_regex, "\\1, '#{partner_version}'")
+
+# Write the changes
+write_podspec(podspec)

--- a/scripts/validate-adapter-and-partner-versions.rb
+++ b/scripts/validate-adapter-and-partner-versions.rb
@@ -1,0 +1,15 @@
+# Validates that an adapter and partner version strings match.
+
+# Parse the version strings from the arguments
+abort "Missing argument. Requires: adapter version string, partner version string." unless ARGV.count == 2
+adapter_version = ARGV[0]
+partner_version = ARGV[1]
+
+# Strip the Chartboost Mediation SDK digit and the adapter build digits
+partner_digits_in_adapter_version = adapter_version.split('.')[1...-1].join('.')
+
+# Strip the cocoapods optimistic operation from the partner version if it exists
+partner_version = partner_version.delete_prefix('~> ')
+
+# Fail if versions don't match
+abort "Validation failed: #{partner_digits_in_adapter_version} != #{partner_version}." unless partner_digits_in_adapter_version == partner_version

--- a/scripts/validate-adapter-version.rb
+++ b/scripts/validate-adapter-version.rb
@@ -1,0 +1,4 @@
+require_relative 'common'
+
+# Fail if versions in podpsec and in the main adapter class don't match
+abort "Validation failed: #{podspec_version} != #{adapter_class_version}." unless podspec_version == adapter_class_version

--- a/scripts/validate-new-release-version.rb
+++ b/scripts/validate-new-release-version.rb
@@ -1,0 +1,22 @@
+# Validates an adapter version string, checking it is well-formed and that it hasn't been released yet.
+
+require_relative 'common'
+
+ADAPTER_VERSION_REGEX = /^[0-9]+(?>\.[0-9]+){4,5}$/
+
+# Parse the new version string from the arguments
+abort "Missing argument. Requires: version string." unless ARGV.count == 1
+new_version = ARGV[0]
+
+# Check that the version is 5 or 6 digits separated by dots.
+abort "Validation failed: #{new_version} is not a well-formed version." unless new_version.match?(ADAPTER_VERSION_REGEX)
+
+# Check if a tag for that version already exists in the remote
+# This command:
+# 1. Fetches all tags from origin
+# 2. Lists all tags that match the new version string
+# 3. Returns the new version string if the corresponding tag was found, empty string otherwise
+version_tag_check = %x( git fetch origin --tags --prune --prune-tags --force && git tag -l "#{new_version}" | head -1)
+
+# Fail if the tag was found
+abort "Validation failed: #{new_version} tag already exists on the remote." unless version_tag_check.empty?

--- a/scripts/validate-partner-version.rb
+++ b/scripts/validate-partner-version.rb
@@ -1,0 +1,12 @@
+# Validates a partner version string checking it is well-formed.
+
+require_relative 'common'
+
+PARTNER_VERSION_REGEX = /^(?>~> )?[0-9]+(?>\.[0-9]+){1,}$/
+
+# Parse the version string from the arguments
+abort "Missing argument. Requires: version string." unless ARGV.count == 1
+version = ARGV[0]
+
+# Fail if the version is not a semantic version with an optional CocoaPods optimistic operator.
+abort "Validation failed: #{version} is not well-formed." unless version.match?(PARTNER_VERSION_REGEX)


### PR DESCRIPTION
Moved existing adapter scripts here.

### Brief
I turned existing workflow steps into one single multi-step composite action.
This way the adapter workflow yml needs to only use one action (e.g. smoke-test) which itself contains all the steps, which can be modified in the future without changes to the adapter repos.

The scripts folder was copy-pasted from the adapter repos without modifications.
The 3 actions ymls were mostly copy-pasted from their corresponding adapter workflows, although needed a few modifications. Mainly:
1. Added description, updated name, etc.
2. Specified a bash `shell` for some steps that did not require it when running on a workflow.
3. Updated the path to the local scripts using `${{ github.action_path }}`. The scripts do not exist in the same path as before since the action is not located in the current path anymore.

### Testing
I tested these changes with the reference adapter, creating a test branch, and running all the actions. I tested the `release` action by first removing the steps to push to CocoaPods and create the GitHub release.

One thing to note is, due to the adapter workflows now containing one single composite action, the output isn't as nice: we don't get those green checks for each step:

<img width="1176" alt="Screenshot 2023-04-25 at 3 21 38 PM" src="https://user-images.githubusercontent.com/9442254/234425154-aea132d2-ca02-4231-802f-b5623973dc2c.png">

<img width="1161" alt="Screenshot 2023-04-25 at 3 21 47 PM" src="https://user-images.githubusercontent.com/9442254/234425175-21c44c72-3210-4a0d-afbc-e80a1852e9c7.png">

We do get all the output and if something fails we get the logs with the failure reason in red.

### Next steps

In separate PRs I will add a step to update file headers, and smoke test and release workflows for this repo.

Also I am about to create PRs for all adapters to use the new actions.