### PR TITLE
Retrieve adapter version from Configuration class.

### DIFF
--- a/scripts/adapters/common.rb
+++ b/scripts/adapters/common.rb
@@ -198,7 +198,7 @@ def adapter_class_file_path
   partner_name = podspec_name.delete_prefix ADAPTER_CLASS_PREFIX()
 
   # Obtain the Adapter file path
-  path = Dir.glob("#{SOURCE_DIR_PATH}/#{partner_name}Adapter.swift").first
+  path = Dir.glob("#{SOURCE_DIR_PATH}/#{partner_name}AdapterConfiguration.swift").first
   fail unless !path.nil?
 
   # Return value


### PR DESCRIPTION
Set the configuration class as the new main adapter class, so version is obtained and modified in it.
This will be released as a v2.0 to not break the integration with 4.x adapters.